### PR TITLE
Restrict to single choice questions

### DIFF
--- a/classes/model/category.php
+++ b/classes/model/category.php
@@ -16,6 +16,8 @@
 
 namespace mod_millionaire\model;
 
+use coding_exception;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -72,42 +74,16 @@ class category extends abstract_model {
     }
 
     /**
-     * Finds a random question id from this category (and its subcategories if allowed) and
-     * returns the moodle question definition for it.
+     * Collects all category ids as array.
      *
-     * @return \question_definition
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * @return int[]
+     * @throws coding_exception
      */
-    public function get_random_question(): \question_definition {
-        global $DB;
-        // build sql for category id(s)
+    public function get_mdl_category_ids() {
         if ($this->includes_subcategories()) {
-            $category_ids = \question_categorylist($this->get_mdl_category());
+            return \question_categorylist($this->get_mdl_category());
         } else {
-            $category_ids = [$this->get_mdl_category()];
-        }
-        list($cat_sql, $cat_params) = $DB->get_in_or_equal($category_ids);
-        // build sql for question type(s)
-        list($qtype_sql, $qtype_params) = $DB->get_in_or_equal(MOD_MILLIONAIRE_VALID_QTYPES_DB);
-        // actual query
-        $sql = "
-            SELECT id
-              FROM {question}
-             WHERE category $cat_sql AND qtype $qtype_sql 
-        ";
-
-        $params = \array_merge($cat_params, $qtype_params);
-        // Get all available questions.
-        $availableids = $DB->get_records_sql($sql, $params);
-        if ($availableids) {
-            // Shuffle here because SQL RAND() can't be used.
-            shuffle($availableids);
-            // Take the first one in the array.
-            $id = $availableids[0]->id;
-            return \question_bank::load_question($id, false);
-        } else {
-            throw new \dml_exception('not found');
+            return [$this->get_mdl_category()];
         }
     }
 

--- a/lib.php
+++ b/lib.php
@@ -55,12 +55,6 @@ define('MOD_MILLIONAIRE_JOKERS', [
     MOD_MILLIONAIRE_JOKER_FEEDBACK
 ]);
 
-// implemented question types
-define('MOD_MILLIONAIRE_QTYPE_SINGLE_CHOICE_DB', 'multichoice');
-define('MOD_MILLIONAIRE_VALID_QTYPES_DB', [
-    MOD_MILLIONAIRE_QTYPE_SINGLE_CHOICE_DB,
-]);
-
 /**
  * Returns the information on whether the module supports a feature
  *

--- a/version.php
+++ b/version.php
@@ -30,5 +30,5 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->component = 'mod_millionaire';
 $plugin->requires = 2017111302;
 $plugin->maturity = MATURITY_BETA;
-$plugin->version = 2019072801;
-$plugin->release = '0.3.11';
+$plugin->version = 2019122601;
+$plugin->release = '0.3.12';


### PR DESCRIPTION
We had the problem that the game only deals with single choice questions, but the question query actually allowed all subtypes of `multichoice`. This is fixed now by joining on the multichoice options table in the question query and allowing only `single=1`.